### PR TITLE
docs: milestone reorder — M6 Smart Intake, M7 Search & Quality

### DIFF
--- a/Meta/Core/Product/Appendix.md
+++ b/Meta/Core/Product/Appendix.md
@@ -20,21 +20,33 @@
 
 ---
 
-## 11. Future Roadmap
+## 11. Roadmap
 
-**Phase 2: Enhanced AI & Polish (Q2 2026)**
-- Advanced consistency checking
+### Active Development
+
+| Milestone | Focus | Status |
+|-----------|-------|--------|
+| M4 | Writing UX Polish | Active |
+| M5 | Export | Draft |
+| M6 | Smart Intake | Draft |
+| M7 | Search, Quality & v0.1.0 Release | Draft |
+
+See [Milestone Index](../../Milestone/Meta.md) for full details.
+See [ADR-0003](../../Decisions/ADR-0003-milestone-reorder-smart-intake.md) for M5→M6→M7 ordering rationale.
+
+### Post-v0.1.0
+
+**M8: Multi-Model AI + Visualization (Q2 2026)**
 - Multi-model support (Claude, GPT, local Ollama)
-- Better context management (embeddings)
-- Plugin/extension system
+- Relationship graph visualization
+- Ambient entity detection during writing
 
-**Phase 3: Power Features (Q3 2026)**
+**M9: Export+ & Plugin System (Q3 2026)**
+- EPUB/PDF export
+- Plugin/extension architecture
 - Style matching from your writing
-- Advanced relationship graph
-- Timeline view for plot
-- EPUB export
 
-**Phase 4: Ecosystem (Q4 2026)**
+**M10: Ecosystem (Q4 2026)**
 - Optional cloud sync (encrypted)
 - Template marketplace
 - VS Code extension

--- a/Meta/Core/Product/MVP.md
+++ b/Meta/Core/Product/MVP.md
@@ -7,40 +7,47 @@
 
 ---
 
-## 8. MVP Scope (Phase 1)
+## 8. MVP Scope
 
-### Must Have (P0)
+**Milestone Path:** M4 (Writing UX) → M5 (Export) → M6 (Smart Intake) → M7 (Search, Quality & v0.1.0)
 
-- [ ] `inxtone` — TUI mode (interactive terminal)
-- [ ] `inxtone init [name]` — Project scaffolding
-- [ ] `inxtone serve` — HTTP Server + TUI
-- [ ] `inxtone serve --no-tui` — Headless mode
-- [ ] Project dashboard (list chapters, word count)
-- [ ] Chapter editor (markdown, manual save)
-- [ ] Character cards (structured data in SQLite)
-- [ ] World rules (basic structure)
-- [ ] Plot outliner (2 levels: Arc → Chapter)
-- [ ] Gemini/Claude integration (continuation, dialogue)
-- [ ] Basic context injection (current chapter + selected entities)
-- [ ] `inxtone export md` — Markdown export
-- [ ] `inxtone export docx` — Word export
-- [ ] `inxtone config set/get` — API key management
+### M4: Writing UX (Active)
 
-### Should Have (P1)
+- [x] Project scaffolding, web UI server, dashboard
+- [x] Chapter editor with auto-save
+- [x] Story Bible: characters, world, locations, factions, timeline, relationships
+- [x] Plot system: arcs, foreshadowing, hooks
+- [x] Gemini 3.0 Pro integration (continuation, dialogue, brainstorm, describe, ask)
+- [x] 5-layer context injection engine
+- [x] Prompt presets (16 presets, 4 categories)
+- [x] Chapter outline editing
+- [x] Brainstorm mode with suggestion cards
+- [ ] Code review fixes (Phase 7)
 
-- [ ] Relationship map (visual, D3.js or similar)
-- [ ] Foreshadowing tracker
-- [ ] Full-text search across project
-- [ ] Multiple AI prompt templates
-- [ ] `inxtone ai ask "question"` — CLI query interface
-- [ ] `inxtone bible list/show/search` — Story Bible CLI
+### M5: Export (Draft)
 
-### Nice to Have (P2)
+- [ ] `inxtone export md/docx/txt` — Multi-format export
+- [ ] Story Bible export (structured document)
+- [ ] Web UI export controls + CLI commands
 
-- [ ] Consistency checker
-- [ ] File watcher (auto-reload on external edit)
-- [ ] Chapter summaries (auto-generated)
-- [ ] Daily word count goals
+### M6: Smart Intake (Draft) — Key Adoption Unlock
+
+**Deliberately excluded from MVP core, but critical for real-world adoption:**
+- [ ] Natural language → Story Bible (paste text → structured entities)
+- [ ] Chapter import + auto-extraction (bulk chapters → full Story Bible)
+- [ ] Outline import → plot architecture
+- [ ] "AI suggests → human confirms" review flow
+
+See [M6.md](../../Milestone/M6.md), [ADR-0003](../../Decisions/ADR-0003-milestone-reorder-smart-intake.md).
+
+### M7: Search, Quality & v0.1.0 (Draft)
+
+- [ ] FTS5 full-text search + Cmd+K modal
+- [ ] Semantic search (sqlite-vec embeddings)
+- [ ] QualityService (26 consistency rules + Wayne Principles)
+- [ ] Version history + diff viewer
+- [ ] CLI completeness, performance, documentation
+- [ ] v0.1.0 release
 
 ---
 
@@ -79,5 +86,7 @@
 
 ## See Also
 
-- [../../Milestone/M1.md](../../Milestone/M1.md) - First milestone tasks
+- [../../Milestone/Meta.md](../../Milestone/Meta.md) - Milestone index
+- [../../Milestone/M6.md](../../Milestone/M6.md) - Smart Intake milestone
+- [../../Decisions/ADR-0003-milestone-reorder-smart-intake.md](../../Decisions/ADR-0003-milestone-reorder-smart-intake.md) - Reorder rationale
 - [Appendix.md](Appendix.md) - Roadmap and risks

--- a/Meta/Core/Product/UserStories.md
+++ b/Meta/Core/Product/UserStories.md
@@ -18,14 +18,18 @@ As a new writer, I want to install Inxtone and start a project quickly so that I
 - `inxtone serve` opens browser with welcome tutorial
 - First chapter creatable within 2 minutes
 
-**US-002: Import Existing Work**
+**US-002: Import Existing Work** `[M6 — Smart Intake]`
 As a writer with an in-progress novel, I want to import my existing chapters and notes so that I can use Inxtone without starting over.
 
 *Acceptance Criteria:*
-- Drop TXT/MD files into chapters/ folder
-- `inxtone import` detects and indexes files
-- AI assists in extracting characters/world info
+- Upload/paste chapter files (TXT/MD/DOCX) or bulk text
+- AI extracts characters, relationships, world rules, plot threads from imported content
+- Step-by-step review: AI suggests → writer confirms/edits → commit to Story Bible
+- Natural language descriptions also accepted (paste character sketch → structured card)
+- Outline import → auto-populate arc structure and chapter goals
 - Original content preserved exactly
+
+*Note: M6 scope, not part of MVP. See [M6.md](../../Milestone/M6.md), [ADR-0003](../../Decisions/ADR-0003-milestone-reorder-smart-intake.md).*
 
 **US-002b: Configure AI**
 As a writer, I want to set up my Gemini API key easily so that I can use AI features.

--- a/Meta/Decisions/ADR-0003-milestone-reorder-smart-intake.md
+++ b/Meta/Decisions/ADR-0003-milestone-reorder-smart-intake.md
@@ -1,0 +1,118 @@
+# ADR-0003: Milestone Reorder — Smart Intake Before Search & Quality
+
+- **Status**: Proposed
+- **Date**: 2026-02-11
+- **Deciders**: Wayne
+
+## Context
+
+After completing M1–M3.5 (Foundation → Story Bible → Writing → Hackathon), the original roadmap was:
+
+```
+M4 (Writing UX polish) → M5 (Export & Polish + MVP release) → M6-M10 (post-MVP features)
+```
+
+Two problems emerged:
+
+**1. The onboarding gap.** Inxtone's Story Bible requires structured data — characters with 3-layer motivations, world rules, foreshadowing ledgers, etc. Currently the only way to populate this is field-by-field form entry. No serious writer will do this. Without a viable intake path, the product is demo-ready but not adoption-ready. Export, CLI polish, and documentation don't solve this.
+
+**2. The M4→M5 scope gap.** M4 deferred several features to M5 — FTS5 search, semantic search, QualityService, auto-suggest entity links, version history. But M5's actual scope is Export & Polish, none of these deferred items. They're effectively homeless.
+
+The core question: **what should the milestone order be between Export, Smart Intake, and Search/Quality?**
+
+## Decision
+
+Reorder post-M4 milestones to prioritize Smart Intake:
+
+```
+M4 (Writing UX)  — in progress, unchanged
+M5 (Export)       — trimmed to export-only, fast completion
+M6 (Smart Intake) — NEW: the key adoption unlock
+M7 (Search + Quality) — absorbs M4's deferred items + original M6-M7 scope
+M8+ (post-MVP)    — multi-model, visualization, EPUB, plugins
+```
+
+### Why Smart Intake as M6 (not before Export)
+
+Export (M5) is small, well-defined, and ships in ~1 week. It completes the basic write→export loop that makes the product minimally useful. Smart Intake is larger and less deterministic (AI extraction quality varies). Shipping Export first means we have a functional MVP while building Intake.
+
+However, Smart Intake is the **first post-export priority**, above search and quality checks. Rationale:
+
+- Search and quality checks need real data volume to be meaningful. Without intake, users have sparse Story Bibles, making these features run on empty.
+- Smart Intake generates the data that makes search and quality valuable.
+- The adoption funnel is: Intake (get data in) → Write → Export (get data out) → Quality (verify). Building Quality before Intake is building the roof before the floor.
+
+### What M6 (Smart Intake) Contains
+
+Three features, all variants of one AI pipeline ("unstructured text → structured Story Bible"):
+
+1. **Natural Language → Story Bible**: Paste character descriptions / world-building / plot outlines in natural language → system auto-decomposes into structured Story Bible entities → user reviews and confirms. The form is the review interface, not the input interface.
+
+2. **Chapter Import → Auto-Extraction**: Import existing chapters (bulk text / files) → AI reads all content → extracts characters, relationships, world rules, locations, factions, foreshadowing → presents structured Story Bible draft → user confirms step-by-step (characters first, then relationships, then world, then plot).
+
+3. **Outline Import → Plot Architecture**: Paste chapter-by-chapter outline → system extracts arc structure, chapter goals, character appearances, foreshadowing plants → pre-populates plot system.
+
+### What M7 (Search + Quality) Contains
+
+Absorbs the orphaned M4 deferrals and original post-MVP quality features:
+
+- FTS5 full-text search + Cmd+K modal
+- Semantic search / embeddings (sqlite-vec)
+- QualityService + quality panel
+- Consistency checker (26 rules)
+- Wayne Principles automated checking
+- Auto-suggest entity links
+- Version history + volume switcher
+
+### Schema Stays Opinionated
+
+Important non-decision: this reorder does **not** introduce user-definable schema. The Story Bible structure (characters with motivation layers, arcs, relationships with Wayne Principle fields, etc.) remains hardcoded. The quality engine's 26 rules depend on these specific fields existing. Smart Intake makes it easier to populate the fixed schema, not to change it. Convention over configuration: extend with custom fields later (M8+), but never remove the structural foundation.
+
+## Alternatives Considered
+
+### Alternative 1: Smart Intake before Export (M5 = Intake, M6 = Export)
+
+- **Pros**: Intake is arguably more critical for adoption than Export
+- **Cons**: Intake is larger and less predictable (AI extraction quality, UX for multi-step confirmation); Export is small and well-defined. Delaying Export means no complete write→export loop for weeks.
+- **Why not**: Export completes the basic product loop quickly. Intake follows immediately after. Net delay to Intake is ~1 week, but we get a shippable MVP sooner.
+
+### Alternative 2: Keep original order (Export → Search/Quality → Intake later)
+
+- **Pros**: Search and quality are technically exciting features
+- **Cons**: Without intake, users have empty Story Bibles. Search searches nothing. Quality checks check nothing. The product looks impressive in demos but nobody can actually use it on their own work.
+- **Why not**: Building downstream features before solving the upstream data problem is backwards.
+
+### Alternative 3: Merge Intake into M5 alongside Export
+
+- **Pros**: Everything ships together as one big MVP
+- **Cons**: M5 balloons from 2 weeks to 5+ weeks. Intake's AI extraction pipeline is complex and needs iteration. Bundling it with Export delays both.
+- **Why not**: Violates the "1-4 week milestone" guideline. Ship Export fast, then focus on Intake.
+
+## Consequences
+
+### Positive
+
+- Adoption path becomes viable: writers with existing work can onboard without manual data entry
+- Search and Quality (M7) will have real data to operate on
+- Export ships fast as a clean, small milestone
+- Each milestone has a clear, singular focus
+
+### Negative
+
+- Search and Quality pushed further out (M7 instead of M5-M6 timeframe)
+- Smart Intake depends on AI extraction quality — may need iteration beyond one milestone
+- Deferred items from M4 wait longer to be addressed
+
+### Risks
+
+- **AI extraction quality**: Gemini may not reliably extract structured Story Bible data from raw chapters. Mitigation: design the UX as "AI suggests, human confirms" — the AI doesn't need to be perfect, it needs to be faster than manual entry.
+- **Scope creep in M6**: Three intake modes could each grow large. Mitigation: Phase 1 (natural language → Bible) is the minimum viable intake; chapter import and outline import can be Phase 2/3 within M6 or spill to M6.5.
+- **M7 becomes a dumping ground**: It absorbs a lot of deferred items. Mitigation: Scope M7 tightly when M6 nears completion; split if needed.
+
+## Related
+
+- [M4.md](../Milestone/M4.md) — Current milestone, deferred items listed in "Out of Scope"
+- [M5.md](../Milestone/M5.md) — Export milestone, to be trimmed
+- [M6.md](../Milestone/M6.md) — Smart Intake milestone (new)
+- [M7.md](../Milestone/M7.md) — Search & Quality milestone (new)
+- [ADR-0002](ADR-0002-ai-context-injection-strategy.md) — Context injection strategy (Intake builds on same AI infrastructure)

--- a/Meta/Milestone/M4.md
+++ b/Meta/Milestone/M4.md
@@ -1,268 +1,170 @@
-# Milestone 4: Search & Quality
+# Milestone 4: AI Quality + Writing UX
 
-- **Status**: Draft
-- **Target Date**: 2026-04-25
+- **Status**: In Progress
+- **Target Date**: 2026-02-20
 - **Owner**: Wayne
-- **Duration**: 2 weeks
+- **Duration**: 10 days
 - **Dependencies**: M3 (Writing Workspace)
 
 ## Goal
 
-Implement **Search** and **Quality Control** features. Users can search across their entire project and receive real-time quality feedback on their writing.
+Close remaining AI quality bugs, deliver writing UX features users need, and address high-priority tech debt. FTS/semantic search and QualityService deferred to M5.
 
 ## Success Criteria
 
-After M4, users should be able to:
-
 ```
-✓ Full-text search across all project content
-✓ Semantic search using embeddings
-✓ Get consistency warnings when writing conflicts with Story Bible
-✓ See quality metrics and suggestions
-✓ Run pre-defined quality checks
+✓ Chapter ordering works correctly (sort_order, not creation ID)
+✓ Auto-save prevents data loss during writing sessions
+✓ Prompt presets provide quick AI instruction chips
+✓ Chapter outlines are editable in the UI
+✓ Brainstorm mode returns selectable suggestion cards
+✓ Code review issues addressed (8 critical/high fixes)
+✓ All 17 GitHub issues closed
 ```
 
 ## Scope
 
 ### In Scope
 
-1. **Search Service (P0/P1)**
-   - Full-text search (SQLite FTS5)
-   - Semantic search (embeddings with sqlite-vec)
-   - Search results ranking
-   - Search across: chapters, characters, world, notes
+1. **AI Quality Bug** — Chapter ordering (#25)
+2. **Auto-save** — Debounced save without version creation (#31)
+3. **Prompt Presets** — Clickable instruction chips (#32)
+4. **Outline Editing** — UI for chapter goal/scenes/hookEnding (#33)
+5. **Brainstorm Redesign** — Selectable suggestion cards (#37)
+6. **Tech Debt** — JSON parsing safety (#2), type assertions (#3), error tests (#6), PR review fixes (#42)
+7. **Code Review Fixes** — 8 critical/high issues from comprehensive review
 
-2. **Quality Service (P1/P2)**
-   - Consistency checking (character details, world rules)
-   - Basic Wayne Principles checking
-   - Pacing analysis (basic)
-   - Repetition detection
+### Out of Scope (Deferred to M5)
 
-3. **Embeddings Infrastructure**
-   - Embedding generation (Gemini embeddings API)
-   - Vector storage (sqlite-vec)
-   - Incremental embedding updates
+- FTS5 search + Cmd+K modal
+- Semantic search / embeddings (sqlite-vec)
+- QualityService + quality panel
+- CLI `inxtone check`
+- Auto-suggest entity links (#28)
+- Interactive StoryBiblePanel (#34)
+- Version history + volume switcher (#35)
 
-4. **UI Components**
-   - Global search modal
-   - Quality panel in editor
-   - Check results display
+## Issue Mapping
 
-### Out of Scope
-
-- Advanced pacing visualizer (future)
-- Custom rule creation (future)
-- Multi-language support
-
-## Deliverables
-
-| # | Deliverable | Acceptance Criteria |
-|---|-------------|---------------------|
-| 1 | **SearchService Implementation** | FTS + semantic search working |
-| 2 | **QualityService Implementation** | Consistency checks running |
-| 3 | **Embeddings Pipeline** | Auto-embed on content change |
-| 4 | **Global Search UI** | Cmd+K search modal |
-| 5 | **Quality Panel** | Real-time quality feedback |
-| 6 | **CLI Commands** | `inxtone check` command |
+| Phase | Closes | Count |
+|-------|--------|-------|
+| Pre-Phase | #20, #21, #22, #23, #24, #26, #27, #29 | 8 |
+| Phase 1 | #25 | 1 |
+| Phase 2 | #31 | 1 |
+| Phase 3 | #32 | 1 |
+| Phase 4 | #33 | 1 |
+| Phase 5 | #37 | 1 |
+| Phase 6 | #2, #3, #6, #42 | 4 |
+| **Total** | | **17** |
 
 ---
 
 ## Tasks
 
-### Phase 1: Search Infrastructure (Day 1-4)
+### Pre-Phase: Close Already-Fixed Issues ✅
 
-- [ ] Implement `SearchRepository`
-  - [ ] FTS5 query builder
-  - [ ] Multi-table search
-  - [ ] Result ranking
-  - [ ] Highlighting
-- [ ] Implement `SearchService`
-  - [ ] Full-text search
-  - [ ] Filter by entity type
-  - [ ] Recent searches
-- [ ] Create `/api/search` endpoints
-  - [ ] GET /api/search?q=&type=&limit=
-  - [ ] GET /api/search/suggest (autocomplete)
-- [ ] Write search tests
+Issues #20-24, #26-27, #29 were already fixed in the codebase during M3 development. Closed with code references.
 
-### Phase 2: Embeddings System (Day 5-7)
+### Phase 1: Chapter Ordering ✅ (#25)
 
-- [ ] Set up sqlite-vec extension
-- [ ] Implement `EmbeddingService`
-  - [ ] Generate embeddings via Gemini API
-  - [ ] Store in embeddings table
-  - [ ] Batch processing
-  - [ ] Incremental updates
-- [ ] Implement semantic search
-  - [ ] Vector similarity query
-  - [ ] Hybrid ranking (FTS + semantic)
-- [ ] Background embedding job
-  - [ ] Queue system for embedding generation
-  - [ ] Rate limiting
-  - [ ] Progress tracking
+- [x] Migration 002: `sort_order INTEGER` column + backfill + composite index
+- [x] Update `WritingRepository`: all queries use `ORDER BY sort_order ASC, id ASC`
+- [x] `createChapter()`: auto-assign `MAX(sort_order) + 1` within volume
+- [x] Real `reorderChapters()`: updates sort_order by array position
+- [x] Add `sortOrder: number` to Chapter entity type
+- [x] Tests: 1016 passing, typecheck clean
 
-### Phase 3: Quality Service (Day 8-11)
+### Code Review Fixes ✅
 
-- [ ] Implement `QualityRepository`
-  - [ ] Store check results
-  - [ ] Query historical checks
-- [ ] Implement `QualityService`
-  - [ ] Character consistency check
-    - [ ] Name consistency
-    - [ ] Appearance consistency
-    - [ ] Personality consistency
-  - [ ] World rule consistency check
-  - [ ] Basic Wayne Principles check
-  - [ ] Repetition detection
-  - [ ] Pacing analysis (basic)
-- [ ] Create `/api/quality` endpoints
-  - [ ] POST /api/quality/check - run checks
-  - [ ] GET /api/quality/results/:chapterId
-  - [ ] GET /api/quality/summary
-- [ ] Rule engine foundation
-  - [ ] Define rule format
-  - [ ] Built-in rules
-  - [ ] Rule execution
+- [x] ChapterListPanel: sort by `sortOrder` (not `id`)
+- [x] ChapterListPanel: defer selection clear to delete `onSuccess`
+- [x] ContextPreview: consistent ID fallback (`idx-N`) in count + render
+- [x] AcceptPreviewModal: ensure exactly `\n\n` paragraph breaks
+- [x] StreamingResponse: only auto-scroll when near bottom
+- [x] AISidebar: abort stream on chapter switch (prevents wrong-chapter accept)
+- [x] AIService: wrap ai_backup in try-catch (non-fatal)
+- [x] BaseContextBuilder: stable sort with secondary index key
 
-### Phase 4: UI Components (Day 12-13)
+### Phase 2: Auto-Save ✅ (#31)
 
-- [ ] **Global Search Modal**
-  - [ ] Cmd+K activation
-  - [ ] Type-ahead suggestions
-  - [ ] Result preview
-  - [ ] Navigate to result
-  - [ ] Filter by type
-- [ ] **Quality Panel**
-  - [ ] Issues list
-  - [ ] Severity indicators
-  - [ ] Jump to issue location
-  - [ ] Dismiss/acknowledge
-- [ ] **Quality Dashboard**
-  - [ ] Overall quality score
-  - [ ] Check history
-  - [ ] Common issues
+- [x] `useAutoSave` hook: 3s debounce → `apiPut` directly (avoids cache overwrite)
+- [x] State: `idle | saving | saved | error`
+- [x] `autoSaveStatus` in editor store
+- [x] Auto-save indicator in toolbar (pulsing dot + status label)
 
-### Phase 5: CLI & Testing (Day 14)
+### Phase 3: Prompt Presets ✅ (#32)
 
-- [ ] Implement `inxtone check [chapter]`
-  - [ ] Run all checks
-  - [ ] Output results
-  - [ ] Exit code for CI
-- [ ] Implement `inxtone search <query>`
-- [ ] End-to-end tests
-- [ ] Performance testing
-  - [ ] Search with 1000+ documents
-  - [ ] Embedding generation speed
+- [x] `presets.ts`: 16 presets across 4 categories (pacing/style/content/character)
+- [x] `PromptPresets.tsx`: category filter tabs + scrollable chip bar
+- [x] Click chip → append to promptText in AISidebar
 
----
+### Phase 4: Outline Editing ✅ (#33)
 
-## Test Plan
+- [x] `OutlinePanel.tsx`: collapsible panel above editor
+- [x] Fields: goal (text), scenes (add/remove list), hookEnding (text)
+- [x] Auto-save outline changes (1.5s debounced `useUpdateChapter`)
 
-### Unit Tests
-- [ ] FTS query building
-- [ ] Embedding vector operations
-- [ ] Quality rule execution
+### Phase 5: Brainstorm Redesign ✅ (#37)
 
-### Integration Tests
-- [ ] Search + FTS5
-- [ ] Embeddings + Gemini API
-- [ ] Quality checks against test data
+- [x] `parseBrainstorm.ts`: parse AI response → suggestion cards
+- [x] `BrainstormPanel.tsx`: card grid with Use/Regenerate/Dismiss actions
+- [x] Restore Brainstorm button in AISidebar
+- [x] 7 unit tests for parser
 
-### E2E Tests
-- [ ] Search → find character → navigate
-- [ ] Write inconsistent content → quality warning
-- [ ] CLI check → see results
+### Phase 6: Tech Debt + Testing ✅ (#2, #3, #6, #42)
+
+- [x] `BaseRepository.parseJson`: optional Zod schema param for runtime validation
+- [x] Type assertions audited — all justified, no unsafe casts
+- [x] Error module: 29 tests covering all 9 error classes + type guards + helpers
+- [x] `mergeContent` utility extracted from AcceptPreviewModal
+- [x] CSS tokens: hardcoded rgba → `var(--color-success-bg)`, z-index → `var(--z-base)`
+- [x] E2E tests: chapter ordering, auto-save, outline (7 tests)
+
+### Phase 7: Code Review Fixes (from comprehensive review)
+
+**Must Fix**
+- [ ] useAutoSave race condition: capture `chapterId` at debounce start, not setTimeout fire
+
+**Should Fix — Auto-Save**
+- [ ] `notifyManualSave()` should clear pending debounce timer
+- [ ] Add AbortController for in-flight save requests on chapter switch/unmount
+- [ ] Add `useAutoSave` unit tests
+
+**Should Fix — Presets**
+- [ ] i18n: 36 hardcoded English strings → `t('key')`
+- [ ] Chip background: hardcoded `rgba` → design token
+- [ ] Add preset data integrity tests (unique IDs, valid categories)
+- [ ] Add `aria-pressed` on category toggle buttons
+
+**Should Fix — Outline**
+- [ ] Hardcoded `#ef4444` → `var(--color-danger)` in OutlinePanel.module.css
+- [ ] Add `aria-expanded` on collapsible header
+- [ ] Add save status indicator for outline changes
+
+**Should Fix — Brainstorm**
+- [ ] Remove redundant `chapterId` guard in AISidebar handleBrainstorm
+- [ ] Add loading state in BrainstormPanel during regeneration
+- [ ] Add parser test cases: en-dash separator, mixed formats
+
+**Should Fix — Docs & Tests**
+- [ ] Update Schema.md with `sort_order` column
+- [ ] Strengthen reorderChapters E2E test (verify actual sort order, not just "doesn't throw")
+- [ ] Define `--color-success-bg` in tokens.css (currently inline fallback only)
+
+**Nits**
+- [ ] Add inline comments to parseBrainstorm regex
+- [ ] Consider dev-mode logging for parseJson Zod validation failures
 
 ---
 
-## Technical Notes
+## Verification
 
-### Search Architecture
-
-```
-User Query
-    ↓
-┌──────────────────────────────────────┐
-│  Query Parser                        │
-│  - Tokenize                          │
-│  - Detect entity hints               │
-└──────────────────────────────────────┘
-    ↓                    ↓
-┌──────────┐      ┌──────────────┐
-│ FTS5     │      │ Semantic     │
-│ Search   │      │ Search       │
-└──────────┘      └──────────────┘
-    ↓                    ↓
-┌──────────────────────────────────────┐
-│  Result Ranker                       │
-│  - Combine scores                    │
-│  - Boost exact matches               │
-│  - Apply filters                     │
-└──────────────────────────────────────┘
-    ↓
-Search Results
-```
-
-### Quality Check Format
-
-```typescript
-interface CheckResult {
-  id: string;
-  type: 'consistency' | 'repetition' | 'pacing' | 'rule';
-  severity: 'error' | 'warning' | 'info';
-  message: string;
-  location?: {
-    chapterId: ChapterId;
-    startOffset: number;
-    endOffset: number;
-  };
-  suggestion?: string;
-  relatedEntities?: Array<{
-    type: 'character' | 'location' | 'world';
-    id: string;
-    name: string;
-  }>;
-}
-```
-
-### Embedding Strategy
-
-```typescript
-// What gets embedded
-const embeddableContent = [
-  { type: 'chapter', fields: ['content', 'outline'] },
-  { type: 'character', fields: ['name', 'appearance', 'motivation'] },
-  { type: 'world', fields: ['rules', 'powerSystem'] },
-  { type: 'location', fields: ['name', 'description'] },
-];
-
-// Chunk strategy for long content
-const CHUNK_SIZE = 500; // tokens
-const CHUNK_OVERLAP = 50; // tokens
-```
-
----
-
-## Dependencies
-
-- M3 must be complete (AI service for embeddings)
-- sqlite-vec extension available
-
-## Risks
-
-| Risk | Likelihood | Impact | Mitigation |
-|------|------------|--------|------------|
-| Embedding API costs | Medium | Medium | Batch processing, caching |
-| sqlite-vec compatibility | Low | High | Test early, fallback to FTS only |
-| False positives in quality checks | High | Medium | Tunable thresholds, dismiss option |
-| Search performance | Medium | Medium | Proper indexing, pagination |
-
----
-
-## Notes
-
-- **核心价值**: Search + Quality 让长篇小说的一致性管理成为可能
-- FTS5 triggers 已在 M1 schema 中创建
-- sqlite-vec 需要编译安装，可能需要 fallback 方案
-- 质量检查初期可以简单，后续迭代增强
-- 考虑质量检查结果的缓存策略
+After all phases:
+1. `pnpm typecheck` — 0 errors
+2. `pnpm test` — all passing
+3. `pnpm build` — clean
+4. Manual: write → stop typing → auto-save indicator appears
+5. Manual: click prompt preset chip → instruction populates → Continue uses it
+6. Manual: open outline panel → fill goal + scenes → Continue → verify AI uses outline
+7. Manual: click brainstorm → suggestion cards → select one → triggers Continue
+8. Manual: reorder chapters → Continue → verify prev-chapter tail is correct

--- a/Meta/Milestone/M5.md
+++ b/Meta/Milestone/M5.md
@@ -1,301 +1,186 @@
-# Milestone 5: Export & Polish
+# Milestone 5: Export
 
 - **Status**: Draft
-- **Target Date**: 2026-05-09
+- **Target Date**: TBD (after M4)
 - **Owner**: Wayne
-- **Duration**: 2 weeks
-- **Dependencies**: M4 (Search & Quality)
+- **Duration**: 1.5 weeks
+- **Dependencies**: M4 (Writing UX)
 
 ## Goal
 
-Implement **Export** functionality and polish the entire application for MVP release. Users can export their work in multiple formats and enjoy a stable, performant experience.
+Implement multi-format export so writers can get their work out of Inxtone. Completes the basic write→export loop. Deliberately kept small and focused — polish, docs, and CLI enhancements move to later milestones.
 
 ## Success Criteria
 
-After M5, Inxtone MVP is ready:
-
 ```
-✓ Export to Markdown, DOCX, TXT formats
-✓ Generate Story Bible documents
-✓ All CLI commands fully functional
-✓ Performance optimized
-✓ Documentation complete
-✓ Ready for public release
+✓ Export chapters to Markdown, DOCX, TXT
+✓ Export Story Bible as structured document
+✓ Export API endpoints functional
+✓ Web UI export controls working
+✓ CLI `inxtone export` command working
 ```
 
 ## Scope
 
 ### In Scope
 
-1. **Export Service (P0)**
-   - Markdown export
-   - DOCX export (Word format)
-   - TXT export (plain text)
-   - Story Bible export (structured document)
+1. **ExportService (P0)**
+   - Markdown export (chapters + front matter + TOC)
+   - DOCX export (chapter headings, page breaks, proper formatting)
+   - TXT export (plain text, chapter separators)
+   - Story Bible export (character summaries, world rules, plot outline)
 
-2. **CLI Polish**
-   - All commands working
-   - Help text complete
-   - Error messages user-friendly
-   - Config management
+2. **Export API (P0)**
+   - `POST /api/export/markdown`
+   - `POST /api/export/docx`
+   - `POST /api/export/txt`
+   - `POST /api/export/story-bible`
+   - Options: chapter range, include outline, include Story Bible
 
-3. **Performance Optimization**
-   - Startup time < 500ms
-   - Memory usage < 100MB idle
-   - Smooth editor experience
+3. **Web UI (P0)**
+   - Export button in toolbar/sidebar
+   - Format selector (MD / DOCX / TXT / Bible)
+   - Chapter range picker (all / volume / custom range)
+   - Download trigger
 
-4. **Documentation**
-   - README.md
-   - Getting Started guide
-   - CLI reference
-   - API documentation
+4. **CLI (P1)**
+   - `inxtone export md [output]`
+   - `inxtone export docx [output]`
+   - `inxtone export txt [output]`
+   - `inxtone export bible [output]`
+   - Options: `--chapters`, `--include-outline`
 
-5. **Bug Fixes & Polish**
-   - Known issues resolved
-   - UI/UX polish
-   - Error handling improved
+### Out of Scope (Deferred)
 
-### Out of Scope
-
-- EPUB export (future)
-- PDF export (future)
-- Cloud sync (future)
-- Plugin system (future)
+- EPUB export → M8+
+- PDF export → M8+
+- Export templates / custom styling → M8+
+- Performance optimization → M7
+- Full documentation / README rewrite → M7
+- CLI polish (config, completion, help text) → M7
+- Accessibility audit → M7
+- v0.1.0 release tagging → after M6 (Smart Intake)
 
 ## Deliverables
 
 | # | Deliverable | Acceptance Criteria |
 |---|-------------|---------------------|
-| 1 | **ExportService Implementation** | All export formats working |
-| 2 | **CLI Commands** | `inxtone export` complete |
-| 3 | **Configuration System** | `inxtone config` complete |
-| 4 | **Documentation** | README, Getting Started, CLI Reference |
-| 5 | **Performance** | Meets all metrics |
-| 6 | **MVP Release** | v0.1.0 tagged and published |
+| 1 | **ExportService** | All 4 formats generate correct output |
+| 2 | **Export API** | 4 endpoints, chapter range filtering works |
+| 3 | **Web UI Export** | Format picker + chapter range + download |
+| 4 | **CLI Export** | `inxtone export` commands functional |
 
 ---
 
 ## Tasks
 
-### Phase 1: Export Service (Day 1-5)
+### Phase 1: ExportService Core (Day 1-4)
 
-- [ ] Implement `ExportService`
-  - [ ] Markdown export
-    - [ ] Chapter content
-    - [ ] Front matter
-    - [ ] Table of contents
-  - [ ] DOCX export
-    - [ ] Use docx library
-    - [ ] Proper formatting
-    - [ ] Chapter headings
-    - [ ] Page breaks
-  - [ ] TXT export
-    - [ ] Plain text
-    - [ ] Chapter separators
-  - [ ] Story Bible export
-    - [ ] Character summaries
-    - [ ] World rules document
-    - [ ] Plot outline
-- [ ] Export templates
-  - [ ] Default templates
-  - [ ] Template variables
-- [ ] Create `/api/export` endpoints
-  - [ ] POST /api/export/markdown
-  - [ ] POST /api/export/docx
-  - [ ] POST /api/export/txt
-  - [ ] POST /api/export/story-bible
+- [ ] Implement `ExportService` interface
+- [ ] Markdown export
+  - [ ] Chapter content with front matter (title, word count, date)
+  - [ ] Table of contents generation
+  - [ ] Volume separators
+- [ ] DOCX export
+  - [ ] Use `docx` library
+  - [ ] Chapter headings (H1)
+  - [ ] Page breaks between chapters
+  - [ ] Basic styling (font, spacing)
+- [ ] TXT export
+  - [ ] Plain text with chapter separators
+  - [ ] Optional: include chapter titles
+- [ ] Story Bible export
+  - [ ] Character summaries (name, role, motivation, arc status)
+  - [ ] World rules overview
+  - [ ] Relationship summary
+  - [ ] Plot outline (arcs, sections, foreshadowing status)
+  - [ ] Output as Markdown document
+- [ ] Tests: each format generates correctly, round-trip verification
 
-### Phase 2: CLI Polish (Day 6-8)
+### Phase 2: API + UI + CLI (Day 4-8)
 
-- [ ] Complete `inxtone export` command
-  - [ ] `inxtone export md [output]`
-  - [ ] `inxtone export docx [output]`
-  - [ ] `inxtone export txt [output]`
-  - [ ] `inxtone export bible [output]`
-  - [ ] Options: --chapters, --include-outline
-- [ ] Complete `inxtone config` command
-  - [ ] `inxtone config list`
-  - [ ] `inxtone config get <key>`
-  - [ ] `inxtone config set <key> <value>`
-  - [ ] API key management (secure storage)
-- [ ] Polish `inxtone ai` command
-  - [ ] `inxtone ai ask "<question>"`
-  - [ ] `inxtone ai continue`
-- [ ] Improve all command help text
-- [ ] Add shell completion (bash, zsh, fish)
+- [ ] Create export API routes
+  - [ ] `POST /api/export/:format` — unified endpoint with format param
+  - [ ] Request body: `{ format, chapterRange?, includeOutline?, includeBible? }`
+  - [ ] Response: file download (Content-Disposition header)
+- [ ] Web UI export controls
+  - [ ] Export button in sidebar or toolbar
+  - [ ] Export modal: format selector, chapter range, options
+  - [ ] Download trigger on completion
+- [ ] CLI commands
+  - [ ] `inxtone export` with format and output path args
+  - [ ] Progress indicator for large exports
+- [ ] Tests: API returns correct file types, UI triggers download
 
-### Phase 3: Performance & Polish (Day 9-11)
+### Phase 3: Polish + Edge Cases (Day 8-10)
 
-- [ ] **Performance Optimization**
-  - [ ] Profile startup time
-  - [ ] Lazy loading for heavy modules
-  - [ ] Database query optimization
-  - [ ] Memory usage audit
-- [ ] **UI Polish**
-  - [ ] Loading states
-  - [ ] Error boundaries
-  - [ ] Empty states
-  - [ ] Keyboard shortcuts
-  - [ ] Responsive design fixes
-- [ ] **Error Handling**
-  - [ ] User-friendly error messages
-  - [ ] Error recovery suggestions
-  - [ ] Crash reporting (optional)
-- [ ] **Accessibility**
-  - [ ] Keyboard navigation
-  - [ ] Screen reader support
-  - [ ] Color contrast verification
-
-### Phase 4: Documentation (Day 12-13)
-
-- [ ] **README.md**
-  - [ ] Project description
-  - [ ] Features overview
-  - [ ] Quick start
-  - [ ] Screenshots
-- [ ] **Getting Started Guide**
-  - [ ] Installation
-  - [ ] First project
-  - [ ] Basic workflow
-- [ ] **CLI Reference**
-  - [ ] All commands documented
-  - [ ] Examples for each
-- [ ] **API Documentation**
-  - [ ] Endpoint reference
-  - [ ] Request/response examples
-- [ ] **Contributing Guide**
-  - [ ] Development setup
-  - [ ] Code style
-  - [ ] PR process
-
-### Phase 5: Testing & Release (Day 14)
-
-- [ ] **Final Testing**
-  - [ ] Full E2E test suite pass
-  - [ ] Manual testing checklist
-  - [ ] Cross-platform verification
-- [ ] **Release Preparation**
-  - [ ] Version bump to 0.1.0
-  - [ ] CHANGELOG.md
-  - [ ] License file
-  - [ ] GitHub release
-  - [ ] npm publish (if applicable)
-- [ ] **Announcements**
-  - [ ] README badges
-  - [ ] Social media assets
+- [ ] Handle large exports (100+ chapters)
+  - [ ] Streaming DOCX generation if needed
+  - [ ] Memory usage check
+- [ ] Empty state handling (no chapters, no Bible data)
+- [ ] Error messages for partial exports (some chapters missing content)
+- [ ] Update CHANGELOG.md
 
 ---
 
 ## Test Plan
 
 ### Unit Tests
-- [ ] Export template rendering
-- [ ] DOCX generation
-- [ ] Config management
+- [ ] Markdown generation: TOC, front matter, content formatting
+- [ ] DOCX generation: document structure, headings, page breaks
+- [ ] TXT generation: separators, encoding
+- [ ] Story Bible export: all entity types included
 
 ### Integration Tests
-- [ ] Full export pipeline
-- [ ] CLI command execution
-- [ ] Config persistence
-
-### E2E Tests
-- [ ] Complete workflow: init → write → export
-- [ ] All CLI commands
-- [ ] All export formats
-
-### Performance Tests
-- [ ] Startup time benchmark
-- [ ] Memory usage monitoring
-- [ ] Export speed with large projects
+- [ ] Full export pipeline: query chapters → generate → return file
+- [ ] Chapter range filtering: single chapter, volume, custom range
+- [ ] Large project export (100+ chapters, performance check)
 
 ---
 
 ## Technical Notes
 
-### Export Templates
+### Export Architecture
 
-```typescript
-interface ExportTemplate {
-  name: string;
-  format: 'md' | 'docx' | 'txt';
-  sections: Array<{
-    type: 'toc' | 'chapters' | 'characters' | 'world' | 'custom';
-    options?: Record<string, unknown>;
-  }>;
-  styles?: {
-    headingFont?: string;
-    bodyFont?: string;
-    fontSize?: number;
-  };
-}
+```
+ExportService
+  ├─ formatters/
+  │   ├─ MarkdownFormatter
+  │   ├─ DocxFormatter
+  │   ├─ TxtFormatter
+  │   └─ BibleFormatter
+  ├─ ExportService.export(options) → Buffer | string
+  └─ Used by: API routes + CLI commands
 ```
 
 ### DOCX Generation
 
 ```typescript
-// Using docx library
-import { Document, Paragraph, HeadingLevel } from 'docx';
-
-const doc = new Document({
-  sections: [{
-    properties: {},
-    children: [
-      new Paragraph({
-        text: chapter.title,
-        heading: HeadingLevel.HEADING_1,
-      }),
-      new Paragraph({
-        text: chapter.content,
-      }),
-    ],
-  }],
-});
+import { Document, Paragraph, HeadingLevel, PageBreak } from 'docx';
 ```
 
 ### Performance Targets
 
-| Metric | Target | Measurement |
-|--------|--------|-------------|
-| Cold start | < 500ms | Time to first render |
-| Hot reload | < 100ms | Time after file change |
-| Memory (idle) | < 100MB | After initial load |
-| Memory (active) | < 300MB | During editing |
-| Export (100 chapters) | < 5s | Time to generate |
+| Metric | Target |
+|--------|--------|
+| Export 100 chapters (MD) | < 2s |
+| Export 100 chapters (DOCX) | < 5s |
+| Export 100 chapters (TXT) | < 1s |
+| Memory during export | < 200MB |
 
 ---
-
-## Dependencies
-
-- M4 must be complete
-- No external dependencies
 
 ## Risks
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|------------|--------|------------|
-| DOCX formatting issues | Medium | Medium | Extensive testing, simple templates |
-| Performance regression | Medium | High | Continuous benchmarking |
-| Documentation incomplete | Medium | Medium | Start early, iterate |
-| Cross-platform bugs | Low | High | CI/CD for all platforms |
+| DOCX formatting issues across readers | Medium | Medium | Test in Word, Google Docs, LibreOffice |
+| Large export memory spikes | Low | Medium | Stream generation, chunk processing |
 
 ---
 
 ## Notes
 
-- **核心价值**: Export 完成后，用户可以将作品导出到任何平台
-- MVP 发布后，收集用户反馈，规划 Phase 2
-- DOCX 可以使用 docx 或 officegen 库
-- 考虑增加导出预览功能
-- Shell completion 可以显著提升 CLI 体验
-
----
-
-## Post-MVP Roadmap Preview
-
-完成 M5 后，进入 Phase 2 (Q2 2026):
-
-1. **M6**: Multi-model AI (Claude, GPT, Ollama)
-2. **M7**: Advanced consistency & embeddings
-3. **M8**: Relationship graph visualization
-4. **M9**: EPUB export & platform publishing
-5. **M10**: Plugin/extension system
+- 故意缩小 scope：Export 是一个快速、确定性高的 milestone，不应该被 polish/docs 拖慢
+- MVP release (v0.1.0) 推迟到 M6 (Smart Intake) 之后 — 没有 intake 的 MVP 不具备真实采用能力
+- Story Bible export 本身也是 Smart Intake (M6) 的反向操作 — 可以验证数据完整性

--- a/Meta/Milestone/M6.md
+++ b/Meta/Milestone/M6.md
@@ -1,0 +1,306 @@
+# Milestone 6: Smart Intake
+
+- **Status**: Draft
+- **Target Date**: TBD (after M5)
+- **Owner**: Wayne
+- **Duration**: 3 weeks
+- **Dependencies**: M5 (Export)
+
+## Goal
+
+Let writers populate Inxtone's Story Bible from natural language, existing chapters, and outlines — instead of field-by-field form entry. The form becomes the review interface, not the input interface. This is the key adoption unlock: without Smart Intake, Inxtone is demo-ready but not adoption-ready.
+
+## Success Criteria
+
+```
+✓ Writer can paste natural language description → structured Story Bible entities created
+✓ Writer can import existing chapters → characters, relationships, world, plot auto-extracted
+✓ Writer can import outline → arc structure, chapter goals, foreshadowing pre-populated
+✓ All intake flows follow "AI suggests → human reviews → confirm" pattern
+✓ Intake produces valid Story Bible data that passes existing consistency rules
+```
+
+## Scope
+
+### In Scope
+
+1. **Natural Language → Story Bible (P0)**
+   - Text input panel: paste or type free-form descriptions
+   - AI decomposition pipeline: text → structured entities (character, relationship, world rule, location, faction, etc.)
+   - Review UI: present extracted entities for confirmation/edit before committing
+   - Batch confirmation: accept all / accept individually / edit and accept
+   - Works for all Story Bible entity types
+
+2. **Chapter Import + Auto-Extraction (P0)**
+   - File upload: accept .txt, .md, .docx chapter files (single or bulk)
+   - Paste mode: paste chapter text directly
+   - AI extraction pipeline: read all chapters → extract characters, relationships, world rules, locations, factions, foreshadowing, plot threads
+   - Step-by-step review: characters first → relationships → world → plot (not all at once)
+   - Merge logic: detect duplicates when importing into existing Story Bible
+   - Chapter content stored in WritingService after import
+
+3. **Outline Import → Plot Architecture (P1)**
+   - Accept outline text (numbered list, nested structure, or prose)
+   - AI extraction: outline → arc structure, sections, chapter goals, character appearances, foreshadowing plants
+   - Review UI: visual arc/chapter structure for confirmation
+   - Pre-populate plot system (arcs, sections, chapter outlines)
+
+### Out of Scope
+
+- Ambient detection during writing (auto-detect new entities as writer types) — M8+
+- User-definable Story Bible schema (custom entity types/fields) — M8+
+- Import from Scrivener, Notion, or other writing tools — future
+- Real-time collaborative import — future
+
+## Deliverables
+
+| # | Deliverable | Acceptance Criteria |
+|---|-------------|---------------------|
+| 1 | **AI Decomposition Pipeline** | Natural language → structured entities, all 9 Bible domains supported |
+| 2 | **Intake API Endpoints** | `POST /api/intake/decompose`, `POST /api/intake/import-chapters`, `POST /api/intake/import-outline` |
+| 3 | **Review & Confirm UI** | Step-by-step entity review, edit-before-commit, batch accept |
+| 4 | **Chapter Import** | Upload/paste chapters → full Story Bible extraction → review → commit |
+| 5 | **Outline Import** | Paste outline → arc/chapter structure extraction → review → commit |
+| 6 | **Duplicate Detection** | Importing into existing Bible detects and handles entity conflicts |
+
+---
+
+## Tasks
+
+### Phase 1: AI Decomposition Pipeline (Day 1-5)
+
+Core AI infrastructure shared by all intake modes.
+
+- [ ] Design `IntakeService` interface
+  - [ ] `decompose(text: string, hint?: EntityType): DecomposedResult`
+  - [ ] `extractFromChapters(chapters: ChapterText[]): ExtractionResult`
+  - [ ] `extractFromOutline(outline: string): OutlineResult`
+- [ ] Implement decomposition prompt templates
+  - [ ] Character extraction prompt (→ name, role, motivation layers, voice, appearance)
+  - [ ] Relationship extraction prompt (→ character pairs, type, dynamics, R1 fields)
+  - [ ] World extraction prompt (→ power system, social rules, constraints)
+  - [ ] Location extraction prompt (→ name, type, atmosphere, significance)
+  - [ ] Faction extraction prompt (→ name, type, goals, resources, conflicts)
+  - [ ] Foreshadowing extraction prompt (→ content, type, planted context, term)
+  - [ ] Arc extraction prompt (→ main/sub arcs, sections, progression)
+- [ ] Implement `IntakeService.decompose()`
+  - [ ] Send text + prompt to Gemini 3.0 Pro
+  - [ ] Parse structured JSON response
+  - [ ] Validate against existing Story Bible schemas (Zod)
+  - [ ] Return typed `DecomposedResult` with confidence scores
+- [ ] Implement response parsing with fallback
+  - [ ] JSON mode when available
+  - [ ] Regex/heuristic fallback for malformed responses
+  - [ ] Partial success handling (some entities parsed, others failed)
+- [ ] Tests: decomposition prompts produce valid schema-conforming output
+
+### Phase 2: Natural Language → Story Bible UI (Day 4-8)
+
+- [ ] Create `IntakePanel.tsx` — main intake interface
+  - [ ] Large text input area (paste / type)
+  - [ ] Entity type hint selector (optional: "I'm describing a character" / "This is world-building" / auto-detect)
+  - [ ] "Decompose" button → loading state → results
+- [ ] Create `IntakeReviewPanel.tsx` — review extracted entities
+  - [ ] Entity cards grouped by type (characters, relationships, world, etc.)
+  - [ ] Each card: preview of extracted data, "Accept" / "Edit" / "Reject"
+  - [ ] "Edit" opens pre-filled Story Bible form (existing form components)
+  - [ ] Batch actions: "Accept All", "Accept All Characters", etc.
+  - [ ] Confidence indicator per entity (high/medium/low extraction confidence)
+- [ ] Create `POST /api/intake/decompose` route
+  - [ ] Accept `{ text, hint?, existingEntityIds? }`
+  - [ ] Return `{ entities: DecomposedEntity[], warnings: string[] }`
+- [ ] Create `POST /api/intake/commit` route
+  - [ ] Accept `{ entities: ConfirmedEntity[] }`
+  - [ ] Write confirmed entities to Story Bible repos in transaction
+  - [ ] Return created entity IDs
+- [ ] Integrate into Web UI navigation (sidebar entry point)
+- [ ] Tests: full flow from text → decompose → review → commit → verify in DB
+
+### Phase 3: Chapter Import + Auto-Extraction (Day 7-14)
+
+- [ ] Create `ChapterImportPanel.tsx`
+  - [ ] File upload zone (drag & drop, .txt / .md / .docx)
+  - [ ] Paste mode (large textarea for direct paste)
+  - [ ] Chapter boundary detection (auto-split by "Chapter N" / "第N章" patterns)
+  - [ ] Manual boundary adjustment if auto-detect fails
+  - [ ] Preview: list of detected chapters with word counts
+- [ ] Implement `IntakeService.extractFromChapters()`
+  - [ ] Chunking strategy: process chapters in batches (context window budget)
+  - [ ] Multi-pass extraction: characters first → relationships → world → plot
+  - [ ] Cross-chapter entity resolution (same character mentioned different ways)
+  - [ ] Foreshadowing detection (plants + hints across chapters)
+- [ ] Create step-by-step review wizard
+  - [ ] Step 1: Characters — extracted character cards, confirm/edit/reject
+  - [ ] Step 2: Relationships — extracted relationships between confirmed characters
+  - [ ] Step 3: World — power system, rules, locations, factions
+  - [ ] Step 4: Plot — arcs, foreshadowing, hooks
+  - [ ] Progress indicator, back/forward navigation
+  - [ ] Each step only shows entities not yet confirmed
+- [ ] Implement duplicate detection
+  - [ ] Name matching (fuzzy: "Chen Wei" = "陈伟" = "Senior Brother Chen")
+  - [ ] AI-assisted: "Is this the same character?" prompt for ambiguous cases
+  - [ ] Merge UI: show existing entity vs. imported entity, let user choose
+- [ ] Chapter content import
+  - [ ] Create chapters in WritingService with imported content
+  - [ ] Link chapter ↔ extracted characters, locations
+  - [ ] Populate chapter outlines from extracted structure
+- [ ] Create `POST /api/intake/import-chapters` route
+  - [ ] Accept `{ chapters: { title, content }[], options? }`
+  - [ ] Return `{ extraction: ExtractionResult, chapterIds: string[] }`
+- [ ] Tests: import sample chapters → verify complete Story Bible generated
+
+### Phase 4: Outline Import (Day 13-17)
+
+- [ ] Create `OutlineImportPanel.tsx`
+  - [ ] Large textarea for outline paste
+  - [ ] Format detection: numbered list / nested headers / prose
+  - [ ] Preview: parsed outline as tree structure
+- [ ] Implement `IntakeService.extractFromOutline()`
+  - [ ] Parse outline structure (arc → volumes → chapters)
+  - [ ] Extract per-chapter: goal, key scenes, characters involved, hook/cliffhanger
+  - [ ] Detect foreshadowing plants mentioned in outline
+  - [ ] Map to arc sections (setup / rising / conflict / climax / resolution)
+- [ ] Create outline review UI
+  - [ ] Visual arc structure (collapsible tree)
+  - [ ] Chapter cards with extracted goals and scenes
+  - [ ] Edit inline before committing
+- [ ] Commit to plot system
+  - [ ] Create arcs + sections
+  - [ ] Create chapter outlines (goal, scenes, hookEnding)
+  - [ ] Plant foreshadowing items
+- [ ] Tests: import sample outlines → verify arc and chapter structure
+
+### Phase 5: Integration + Polish (Day 16-21)
+
+- [ ] Unified intake entry point
+  - [ ] "Import" button in sidebar → modal with 3 tabs (Text / Chapters / Outline)
+  - [ ] Dashboard empty state includes intake CTA
+  - [ ] Welcome screen adds "Import Existing Work" option
+- [ ] Error handling
+  - [ ] AI extraction failure → graceful fallback ("couldn't parse, try shorter text")
+  - [ ] Partial extraction → show what succeeded, let user retry rest
+  - [ ] Network/API errors → retry with backoff
+- [ ] Performance
+  - [ ] Progress indicator for long extractions (chapter import may take minutes)
+  - [ ] Streaming status updates via SSE ("Analyzing chapter 3 of 50...")
+  - [ ] Cancel button for long operations
+- [ ] E2E test: empty project → import 10 chapters → review all entities → full Story Bible populated
+- [ ] E2E test: existing project → import new chapters → duplicate detection → merge
+- [ ] Update Progress.md, CHANGELOG.md
+
+---
+
+## Test Plan
+
+### Unit Tests
+- [ ] Decomposition prompt templates produce valid JSON for each entity type
+- [ ] Schema validation catches malformed AI responses
+- [ ] Duplicate detection: exact match, fuzzy match, no-match cases
+- [ ] Chapter boundary detection: Chinese patterns, English patterns, mixed
+- [ ] Outline parser: numbered lists, nested headers, prose formats
+
+### Integration Tests
+- [ ] Full decompose pipeline: text → AI → parse → validate → return
+- [ ] Full chapter import pipeline: upload → chunk → extract → review → commit
+- [ ] Full outline import pipeline: paste → parse → extract → review → commit
+- [ ] Commit transaction: all entities written atomically, rollback on failure
+
+### E2E Tests
+- [ ] Empty project + natural language intake → Story Bible populated
+- [ ] Empty project + chapter import (10 chapters) → complete Story Bible + chapters
+- [ ] Existing project + chapter import → duplicate detection + merge
+- [ ] Outline import → arc and chapter structure populated
+- [ ] Import + then write with AI → context engine picks up imported entities
+
+---
+
+## Technical Notes
+
+### AI Decomposition Architecture
+
+```
+User Input (text / chapters / outline)
+         │
+         v
+   IntakeService
+         │
+         ├─ Prompt Template (entity-type-specific)
+         │
+         ├─ Gemini 3.0 Pro (structured output)
+         │
+         ├─ Response Parser (JSON → typed entities)
+         │
+         ├─ Schema Validator (Zod — same schemas as repos)
+         │
+         v
+   DecomposedResult { entities, confidence, warnings }
+         │
+         v
+   Review UI (human confirms)
+         │
+         v
+   Commit (repos write in transaction)
+```
+
+### Chunking Strategy for Chapter Import
+
+```
+Total chapters: N
+Context window: ~1M tokens (Gemini 3.0 Pro)
+
+Strategy:
+- First pass: send ALL chapters as read-only context
+  → extract character list, relationship list, world rules
+  (Gemini 3.0 Pro's 1M context can handle ~500K words)
+
+- Second pass (if needed): per-arc detailed extraction
+  → foreshadowing, hooks, pacing within arc boundaries
+
+- Entity resolution: cross-reference extracted entities across passes
+```
+
+### Duplicate Detection Approach
+
+```typescript
+interface DuplicateCandidate {
+  imported: StoryBibleEntity;
+  existing: StoryBibleEntity;
+  confidence: number; // 0-1
+  reason: string;     // "exact name match" | "AI similarity" | "alias match"
+}
+
+// Tiered matching:
+// 1. Exact name match → confidence 0.95+
+// 2. Alias/nickname match → confidence 0.7-0.9
+// 3. AI-assisted ("same entity?") → confidence varies
+// 4. No match → create new
+```
+
+---
+
+## Dependencies
+
+- M5 (Export) complete — basic product loop established
+- Gemini 3.0 Pro API — structured output / JSON mode preferred
+- Existing Story Bible repos — write targets for committed entities
+- Existing form components — reused in review/edit UI
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| AI extraction quality inconsistent | High | High | "AI suggests, human confirms" UX — AI doesn't need to be perfect, just faster than manual |
+| Chapter import takes too long (minutes) | Medium | Medium | Streaming progress updates, chunked processing, cancel support |
+| Duplicate detection false positives | Medium | Medium | Always show both entities side-by-side, let user decide |
+| Scope creep across 3 intake modes | Medium | High | P0 = natural language + chapter import. Outline import (P1) can spill to M6.5 |
+| Structured output format varies | Medium | Medium | Zod validation + fallback parsing, retry on failure |
+
+---
+
+## Notes
+
+- Natural language intake 是最小可行 intake — 即使 chapter import 延期，用户至少可以粘贴描述来快速建库
+- Chapter import 是最高价值 intake — 已有作品的作者是最可能的早期用户
+- Review UI 复用现有 Story Bible 表单组件，不需要从零设计
+- Confidence score 帮助用户决定哪些需要仔细审查，哪些可以直接 accept
+- 后续 M8+ 可以在此基础上加 ambient detection（写作过程中自动发现新实体）

--- a/Meta/Milestone/M7.md
+++ b/Meta/Milestone/M7.md
@@ -1,0 +1,242 @@
+# Milestone 7: Search, Quality & Polish
+
+- **Status**: Draft
+- **Target Date**: TBD (after M6)
+- **Owner**: Wayne
+- **Duration**: 3 weeks
+- **Dependencies**: M6 (Smart Intake)
+
+## Goal
+
+Implement full-text and semantic search, the QualityService consistency checker, and application-wide polish (performance, docs, CLI, accessibility). This is the milestone that makes Inxtone production-ready for v0.1.0 release. Depends on M6 (Smart Intake) because search and quality need real data volume to be meaningful.
+
+## Success Criteria
+
+```
+✓ Cmd+K search modal with instant full-text results across all entities
+✓ Semantic search via sqlite-vec embeddings
+✓ QualityService runs 26 consistency rules
+✓ Quality panel shows issues with severity and location
+✓ Wayne Principles automated checking
+✓ CLI `inxtone check` and `inxtone search` commands
+✓ Performance targets met (startup < 500ms, idle memory < 100MB)
+✓ Documentation complete (README, Getting Started, CLI reference)
+✓ v0.1.0 tagged and published
+```
+
+## Scope
+
+### In Scope
+
+1. **Full-Text Search (P0)**
+   - FTS5 virtual table across characters, chapters, world, arcs, foreshadowing
+   - Cmd+K modal in Web UI — instant search as you type
+   - Search results grouped by entity type, linked to detail views
+   - CLI: `inxtone search "<query>"`
+
+2. **Semantic Search (P1)**
+   - sqlite-vec embedding storage
+   - Gemini embedding API integration
+   - Index: characters, world, chapters, outlines
+   - Chunking: max 500 chars, 50-char overlap
+   - Hybrid ranking: FTS5 score + vector similarity
+
+3. **QualityService (P0)**
+   - 26 consistency rules across 6 dimensions
+     - Character consistency (6): voice, behavior, power, dialogue distinction, arc progression, relationship evolution
+     - World consistency (4): rule violations, location match, faction stance, timeline order
+     - Plot consistency (4): foreshadowing status, subplot alignment, arc structure, MC arc sync
+     - Wayne principles (4+2): R1-R4 red lines + P1-P4 core principles
+     - Pacing & quality (4): golden chapters, emotion curve, chapter hooks, repetition detection
+     - Text quality (2): writing traps detection
+   - Check scheduling: realtime / on-chapter-complete / every-10-chapters / event-triggered
+   - Issue aggregation with severity levels
+
+4. **Quality Panel UI (P0)**
+   - Quality tab in sidebar or dedicated panel
+   - Issue list: severity, rule, location (chapter + entity), description
+   - Issue detail: explanation, suggestion, link to source
+   - Run check button (manual trigger)
+   - Wayne Principle check summary card
+   - Consistency badge on chapters
+
+5. **Auto-Suggest Entity Links (P1)**
+   - Detect entity mentions in chapter text
+   - Suggest links to Story Bible entries
+   - Interactive StoryBiblePanel in editor sidebar
+
+6. **Version History (P1)**
+   - Version history panel for chapters
+   - Diff viewer between versions
+   - Restore from version
+   - Volume switcher
+
+7. **CLI Completeness (P0)**
+   - `inxtone check` — run quality checks
+   - `inxtone search` — full-text search
+   - `inxtone config` — configuration management
+   - Shell completion (bash, zsh, fish)
+   - Improved help text across all commands
+
+8. **Performance & Polish (P0)**
+   - Startup time < 500ms
+   - Idle memory < 100MB
+   - Loading states, error boundaries, empty states
+   - Keyboard shortcuts
+   - Responsive design fixes
+
+9. **Documentation & Release (P0)**
+   - README.md with screenshots
+   - Getting Started guide
+   - CLI reference
+   - API documentation
+   - Contributing guide
+   - v0.1.0 release tag
+
+### Out of Scope
+
+- Multi-model AI (Claude, GPT, Ollama) → M8
+- Relationship graph visualization → M8
+- EPUB/PDF export → M8
+- Plugin/extension system → M9
+- Cloud sync → M9
+- Ambient entity detection during writing → M8
+
+## Deliverables
+
+| # | Deliverable | Acceptance Criteria |
+|---|-------------|---------------------|
+| 1 | **SearchService** | FTS5 + semantic search, Cmd+K modal, CLI command |
+| 2 | **QualityService** | 26 rules implemented, check scheduling, issue aggregation |
+| 3 | **Quality Panel** | Issue list/detail, manual trigger, badges |
+| 4 | **Entity Links** | Auto-detect mentions, suggest links, interactive panel |
+| 5 | **Version History** | Version list, diff viewer, restore |
+| 6 | **CLI Complete** | All commands documented and functional |
+| 7 | **Performance** | All metrics met |
+| 8 | **Documentation** | README, guides, API docs |
+| 9 | **v0.1.0 Release** | Tagged, CHANGELOG complete |
+
+---
+
+## Tasks
+
+### Phase 1: Search (Day 1-5)
+
+- [ ] FTS5 virtual table migration
+  - [ ] Index: characters (name, appearance, motivation), chapters (title, content), world, arcs, foreshadowing, locations, factions
+  - [ ] Triggers for auto-update on insert/update/delete
+- [ ] SearchService implementation
+  - [ ] `search(query, options?)` — FTS5 query with ranking
+  - [ ] Results grouped by entity type
+  - [ ] Highlight matching snippets
+- [ ] Cmd+K search modal
+  - [ ] Keyboard shortcut trigger
+  - [ ] Instant search as you type (debounced)
+  - [ ] Result cards with entity type icon, name, snippet
+  - [ ] Click result → navigate to entity detail
+- [ ] sqlite-vec integration (P1)
+  - [ ] Embedding table migration
+  - [ ] Gemini embedding API calls
+  - [ ] Index existing entities on first run
+  - [ ] Hybrid ranking: combine FTS5 + vector scores
+- [ ] CLI: `inxtone search "<query>"`
+- [ ] Tests: FTS5 indexing, search accuracy, ranking
+
+### Phase 2: Quality (Day 5-12)
+
+- [ ] QualityService interface and implementation
+  - [ ] Rule engine: load rules from config, execute, aggregate results
+  - [ ] Issue type: `{ rule, severity, entityType, entityId, chapterId?, description, suggestion }`
+  - [ ] Batch check: run all applicable rules for a scope (chapter / volume / all)
+- [ ] Implement consistency rules (26 total)
+  - [ ] Character rules (6)
+  - [ ] World rules (4)
+  - [ ] Plot rules (4)
+  - [ ] Wayne principles (6)
+  - [ ] Pacing rules (4)
+  - [ ] Text quality rules (2)
+- [ ] Check scheduling
+  - [ ] On-demand (manual trigger)
+  - [ ] On chapter complete
+  - [ ] Periodic (every N chapters)
+- [ ] Quality panel UI
+  - [ ] Issue list with filters (severity, type, chapter)
+  - [ ] Issue detail view
+  - [ ] Run check button
+  - [ ] Consistency badges on chapter list
+- [ ] Quality API routes
+  - [ ] `POST /api/quality/check` — run checks
+  - [ ] `GET /api/quality/issues` — list issues
+  - [ ] `GET /api/quality/summary` — overview stats
+- [ ] CLI: `inxtone check` — run quality checks, print report
+- [ ] Tests: each rule produces correct issues for known-bad input
+
+### Phase 3: Entity Links + Version History (Day 10-15)
+
+- [ ] Auto-suggest entity links
+  - [ ] Text analysis: detect character names, location names in chapter content
+  - [ ] Suggestion UI: inline highlights or sidebar suggestions
+  - [ ] Click to link → navigate to Story Bible entry
+- [ ] Interactive StoryBiblePanel
+  - [ ] Quick-reference panel in editor sidebar
+  - [ ] Shows entities related to current chapter
+  - [ ] Click to expand details
+- [ ] Version history
+  - [ ] Version list panel for chapters
+  - [ ] Diff viewer (visual diff between versions)
+  - [ ] Restore button → creates new version from old content
+  - [ ] Volume switcher in sidebar
+- [ ] Tests: entity detection accuracy, version create/restore/diff
+
+### Phase 4: CLI + Performance + Docs + Release (Day 14-21)
+
+- [ ] CLI completeness
+  - [ ] `inxtone config list/get/set`
+  - [ ] Shell completion scripts
+  - [ ] Help text review for all commands
+- [ ] Performance optimization
+  - [ ] Profile startup time, optimize lazy loading
+  - [ ] Database query audit
+  - [ ] Memory usage monitoring
+- [ ] UI polish
+  - [ ] Loading states everywhere
+  - [ ] Error boundaries
+  - [ ] Empty states
+  - [ ] Keyboard shortcuts reference
+- [ ] Documentation
+  - [ ] README.md rewrite with screenshots
+  - [ ] Getting Started guide
+  - [ ] CLI reference
+  - [ ] API endpoint documentation
+  - [ ] Contributing guide
+- [ ] Release
+  - [ ] Version bump to 0.1.0
+  - [ ] CHANGELOG.md
+  - [ ] GitHub release
+  - [ ] Social media assets
+
+---
+
+## Dependencies
+
+- M6 (Smart Intake) complete — users have real data in Story Bibles
+- sqlite-vec npm package — for embedding storage
+- Gemini embedding API — for vector generation
+
+## Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Milestone too large (3 weeks) | High | Medium | Phase 1-2 are core; Phase 3-4 can be trimmed or split to M7.5 |
+| sqlite-vec compatibility | Medium | High | Test early; fallback to FTS5-only if needed |
+| Quality rules too simplistic | Medium | Medium | Start with high-confidence rules, iterate based on user feedback |
+| Documentation takes longer than expected | Medium | Low | Write incrementally during development, not all at end |
+
+---
+
+## Notes
+
+- 这是 v0.1.0 release milestone — 完成后 Inxtone 正式可用
+- Quality 规则可以迭代 — 先实现高信度规则，后续版本逐步增加
+- 如果 milestone 过大，优先砍 P1 项目（semantic search、entity links、version history），保 P0
+- Search + Quality 在 Intake 之后才有意义：没有数据的搜索是空搜索，没有数据的质量检查是空检查

--- a/Meta/Milestone/Meta.md
+++ b/Meta/Milestone/Meta.md
@@ -30,11 +30,24 @@ Draft → Active → Complete → Archived
 
 | Milestone | Title | Status | Target | Duration |
 |-----------|-------|--------|--------|----------|
-| [M1](M1.md) | Foundation + Interface Contract | Complete | 2026-02-28 | 2 weeks |
-| [M2](M2.md) | Story Bible Core | Complete | 2026-03-21 | 3 weeks |
-| [M3](M3.md) | Writing Workspace | Active | 2026-04-11 | 3 weeks |
-| [M4](M4.md) | Search & Quality | Draft | 2026-04-25 | 2 weeks |
-| [M5](M5.md) | Export & Polish (MVP) | Draft | 2026-05-09 | 2 weeks |
+| [M1](M1.md) | Foundation + Interface Contract | Complete | 2026-02-05 | 1 day |
+| [M2](M2.md) | Story Bible Core | Complete | 2026-02-07 | 2 days |
+| [M3](M3.md) | Writing Workspace + AI | Complete | 2026-02-08 | 1 day |
+| [M3.5](M3.5.md) | Hackathon Submission | Complete | 2026-02-09 | 1 day |
+| [M4](M4.md) | Writing UX Polish | Active | 2026-02-20 | 10 days |
+| [M5](M5.md) | Export | Draft | TBD | 1.5 weeks |
+| [M6](M6.md) | Smart Intake | Draft | TBD | 3 weeks |
+| [M7](M7.md) | Search, Quality & v0.1.0 Release | Draft | TBD | 3 weeks |
+
+### Post-MVP Roadmap
+
+| Milestone | Title | Status |
+|-----------|-------|--------|
+| M8 | Multi-Model AI + Relationship Graph + Ambient Detection | Draft |
+| M9 | EPUB/PDF Export + Plugin System | Draft |
+| M10 | Cloud Sync + Community Features | Draft |
+
+See [ADR-0003](../Decisions/ADR-0003-milestone-reorder-smart-intake.md) for rationale behind M5→M6→M7 ordering.
 
 ## Creating a New Milestone
 

--- a/Meta/Todo.md
+++ b/Meta/Todo.md
@@ -4,14 +4,29 @@
 
 ---
 
-## High Priority (M2 — Story Bible Core)
+## High Priority (M4 Phase 7 — Code Review Fixes)
 
-- [x] **M2 Phase 1: Repository Layer** — 7 repositories + 341 tests (2026-02-07)
-- [x] **M2 Phase 2: Service Layer** — EventBus + StoryBibleService + 61 tests (2026-02-07)
-- [x] **M2 Phase 3: API Layer** — 45 endpoints, 9 domains, 76 route tests (2026-02-07)
-- [ ] **M2 Phase 4: Web UI** — Character, World, Relationship pages
-- [ ] **M2 Phase 5: CLI Commands** — `inxtone bible list/show/search`
-- [ ] **M2 Phase 6: Testing & Polish** — E2E tests, performance testing
+**Must Fix**
+- [ ] **useAutoSave race condition** — capture chapterId at debounce start, not setTimeout fire
+
+**Should Fix**
+- [ ] **Auto-save collision** — `notifyManualSave()` clear pending timer + AbortController for in-flight requests
+- [ ] **useAutoSave unit tests** — no client-side test coverage
+- [ ] **i18n: prompt presets** — 36 hardcoded English strings → `t('key')`
+- [ ] **Outline CSS** — hardcoded `#ef4444` → `var(--color-danger)`
+- [ ] **Brainstorm loading state** — no feedback during regeneration
+- [ ] **tokens.css** — define `--color-success-bg`, chip bg token
+- [ ] **Schema.md** — add `sort_order` column
+- [ ] **Accessibility** — `aria-pressed` on preset toggles, `aria-expanded` on outline header
+- [ ] **reorderChapters E2E** — verify actual sort order persisted
+- [ ] **Preset tests** — data integrity (unique IDs, valid categories)
+- [ ] **Brainstorm parser tests** — en-dash separator, mixed formats
+- [ ] **Outline save indicator** — no user feedback on outline auto-save
+- [ ] **Redundant chapterId guard** — AISidebar handleBrainstorm
+
+**Nits**
+- [ ] parseBrainstorm regex inline comments
+- [ ] Dev-mode logging for parseJson Zod failures
 
 ## Medium Priority
 

--- a/_docs/Product.md
+++ b/_docs/Product.md
@@ -224,16 +224,20 @@ Acceptance Criteria:
 ```
 
 ```
-US-002: Import Existing Work
+US-002: Import Existing Work [M6 — Smart Intake]
 As a writer with an in-progress novel
 I want to import my existing chapters and notes
 So that I can use Inxtone without starting over
 
 Acceptance Criteria:
-- Drop TXT/MD files into chapters/ folder
-- `inxtone import` detects and indexes files
-- AI assists in extracting characters/world info into Story Bible
-- Original content preserved exactly (files not modified)
+- Upload/paste chapter files (TXT/MD/DOCX) or bulk text
+- AI extracts characters, relationships, world rules, plot threads from imported content
+- Step-by-step review: AI suggests → writer confirms/edits → commit to Story Bible
+- Natural language descriptions also accepted (paste a character sketch → structured card)
+- Original content preserved exactly
+
+Note: This is M6 (Smart Intake), not part of MVP scope.
+See Meta/Milestone/M6.md for full scope, ADR-0003 for rationale.
 ```
 
 ```
@@ -893,36 +897,59 @@ For million-word novels, context management is critical:
 
 ---
 
-## 8. MVP Scope (Phase 1)
+## 8. MVP Scope
 
-**Timeline:** 6-10 weeks (faster without server infrastructure)
+**Milestone Mapping:** M4 (Writing UX) → M5 (Export) → M6 (Smart Intake) → M7 (Search, Quality & v0.1.0)
 
-**Must Have (P0):**
-- [ ] `inxtone init` — Project scaffolding
-- [ ] `inxtone serve` — Local web UI server
-- [ ] Project dashboard (list chapters, word count)
-- [ ] Chapter editor (markdown, manual save)
-- [ ] Character cards (markdown + frontmatter)
-- [ ] World rules (basic structure)
-- [ ] Plot outliner (2 levels: Arc → Chapter)
-- [ ] Gemini integration (continuation, dialogue)
-- [ ] Basic context injection (current chapter + selected entities)
-- [ ] `inxtone export --txt` — TXT export
-- [ ] `inxtone export --docx` — Word export
+### M4–M5: Core Product Loop (Writing + Export)
+
+**Must Have (P0) — M4:**
+- [x] `inxtone init` — Project scaffolding
+- [x] `inxtone serve` — Local web UI server
+- [x] Project dashboard (list chapters, word count)
+- [x] Chapter editor with auto-save
+- [x] Character cards (structured data in SQLite)
+- [x] World rules, locations, factions, timeline
+- [x] Plot system (arcs, foreshadowing, hooks)
+- [x] Gemini 3.0 Pro integration (continuation, dialogue, brainstorm)
+- [x] 5-layer context injection engine
+- [x] Prompt presets (16 presets, 4 categories)
+- [x] Chapter outline editing
+- [x] Brainstorm mode with selectable suggestion cards
 - [ ] `inxtone config` — API key management
 
-**Should Have (P1):**
-- [ ] Relationship map (visual, D3.js or similar)
-- [ ] Foreshadowing tracker
-- [ ] Full-text search across project
-- [ ] Multiple AI prompt templates
-- [ ] `inxtone ask` — CLI query interface
+**Must Have (P0) — M5:**
+- [ ] `inxtone export md/docx/txt` — Multi-format export
+- [ ] Story Bible export (structured document)
+- [ ] Web UI export controls
 
-**Nice to Have (P2):**
-- [ ] Consistency checker
-- [ ] File watcher (auto-reload on external edit)
-- [ ] Chapter summaries (auto-generated)
-- [ ] Daily word count goals
+### M6: Smart Intake (Key Adoption Unlock)
+
+**Not part of MVP core, but critical for real-world adoption:**
+- [ ] Natural language → Story Bible (paste text → structured entities)
+- [ ] Chapter import + auto-extraction (bulk chapters → full Story Bible)
+- [ ] Outline import → plot architecture
+- [ ] "AI suggests → human confirms" review flow
+
+See [M6.md](Meta/Milestone/M6.md) and [ADR-0003](Meta/Decisions/ADR-0003-milestone-reorder-smart-intake.md).
+
+### M7: Search, Quality & v0.1.0 Release
+
+- [ ] FTS5 full-text search + Cmd+K modal
+- [ ] Semantic search (sqlite-vec embeddings)
+- [ ] QualityService (26 consistency rules)
+- [ ] Wayne Principles automated checking
+- [ ] Version history + diff viewer
+- [ ] Performance optimization, documentation, v0.1.0 release
+
+### Deferred (Post-v0.1.0)
+
+- Consistency checker (advanced, AI-powered)
+- Multi-model support (Claude, GPT, Ollama)
+- Relationship graph visualization
+- EPUB/PDF export
+- Plugin system
+- Cloud sync
 
 ---
 
@@ -973,28 +1000,36 @@ For million-word novels, context management is critical:
 
 ---
 
-## 11. Future Roadmap (Post-MVP)
+## 11. Roadmap
 
-**Phase 2: Enhanced AI & Polish (Q2 2026)**
-- Advanced consistency checking
+### Active Development (M4–M7)
+
+| Milestone | Focus | Status |
+|-----------|-------|--------|
+| M4 | Writing UX Polish | Active |
+| M5 | Export | Draft |
+| M6 | Smart Intake | Draft |
+| M7 | Search, Quality & v0.1.0 | Draft |
+
+See [Milestone Index](Meta/Milestone/Meta.md) for details.
+
+### Post-v0.1.0
+
+**M8: Multi-Model AI + Visualization (Q2 2026)**
 - Multi-model support (Claude, GPT, local Ollama)
-- Better context management (embeddings, semantic search)
-- Plugin/extension system
+- Relationship graph visualization
+- Ambient entity detection during writing
+- Advanced consistency checking
 
-**Phase 3: Power Features (Q3 2026)**
-- Style matching/learning from your writing
-- Advanced relationship graph visualization
-- Timeline view for plot
-- EPUB/Kindle export
+**M9: Export+ & Plugin System (Q3 2026)**
+- EPUB/PDF export
+- Plugin/extension architecture
+- Style matching from your writing
 
-**Phase 4: Ecosystem (Q4 2026)**
+**M10: Ecosystem (Q4 2026)**
 - Optional cloud sync (encrypted, user-controlled)
 - Template marketplace (share Story Bible templates)
-- VS Code extension (edit in IDE, sync with web UI)
-
-**Phase 5: Community (2027)**
-- Writing challenges/events
-- Optional public story sharing
+- VS Code extension
 - Community-contributed prompts
 
 ---


### PR DESCRIPTION
## Summary

- **ADR-0003**: Documents the decision to reorder post-M4 milestones: Export (M5) → Smart Intake (M6) → Search & Quality (M7)
- **M6 (Smart Intake)**: New milestone — natural language → Story Bible, chapter import + auto-extraction, outline import. The key adoption unlock.
- **M7 (Search, Quality & v0.1.0)**: New milestone — absorbs M4 deferred items (FTS5, semantic search, QualityService, version history) + v0.1.0 release
- **M4**: Mark completed phases 2-6, add Phase 7 (code review fixes from comprehensive review)
- **M5**: Trim from "Export & Polish" to just "Export" (~1.5 weeks)
- **Updated**: Milestone index, Todo.md, MVP scope, Product.md, Appendix roadmap, UserStories

## Rationale

Without Smart Intake, Inxtone requires field-by-field Story Bible entry — no serious writer will do this. Search and Quality need real data volume to be meaningful, so they follow Intake. Export ships first because it's small and completes the basic write→export loop.

## Test plan

- [x] All markdown links resolve correctly
- [x] Cross-references between ADR-0003, M6, M7, and existing docs are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)